### PR TITLE
Avoid chrono deprecation nags; one clippy ref-ref nag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # macOS junk
 .DS_Store
+
+# vsCode
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ let rd = RelativeDuration::months(1).with_days(-2);
 
 // It also compatible with NaiveDate
 assert_eq!(
-    NaiveDate::from_ymd(2022, 1, 1) + rd,
-    NaiveDate::from_ymd(2022, 1, 30)
+    NaiveDate::from_ymd_opt(2022, 1, 1).unwrap() + rd,
+    NaiveDate::from_ymd_opt(2022, 1, 30).unwrap()
 );
 ```
 
@@ -79,12 +79,12 @@ assert_eq!(rd, parsed.rd)
 use calends::{Recurrence, Rule};
 use chrono::NaiveDate;
 
-let date = NaiveDate::from_ymd(2022, 1, 1);
-let end = NaiveDate::from_ymd(2022, 3, 1);
+let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
 
 let mut recur = Recurrence::with_start(Rule::monthly(), date).until(end);
-assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 1, 1)));
+assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 2, 1)));
 assert_eq!(recur.next(), None);
 ```
 
@@ -107,7 +107,7 @@ use calends::{Interval, RelativeDuration};
 use chrono::NaiveDate;
 
 let duration = RelativeDuration::months(1).with_days(-2);
-let start = NaiveDate::from_ymd(2022, 1, 1);
+let start = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
 
 let mut interval = Interval::closed_from_start(start, duration);
 ```
@@ -130,7 +130,7 @@ struct S {
 }
 
 let rd = RelativeDuration::default().with_days(1).with_months(23).with_weeks(-1);
-let int = Interval::closed_from_start(NaiveDate::from_ymd(2022, 1, 1), rd);
+let int = Interval::closed_from_start(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), rd);
 let s = S { i: int.clone() };
 
 let int_string = serde_json::to_string(&s).unwrap();

--- a/src/duration/relative.rs
+++ b/src/duration/relative.rs
@@ -59,13 +59,13 @@ impl RelativeDuration {
     /// # use chrono::NaiveDate;
     ///
     /// let duration = RelativeDuration::from_duration_between(
-    ///     NaiveDate::from_ymd(2022, 1, 1),
-    ///     NaiveDate::from_ymd(2023, 1, 1),
+    ///     NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
     ///  );
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 1, 1) + duration,
-    ///     NaiveDate::from_ymd(2023, 1, 1)
+    ///     NaiveDate::from_ymd_opt(2022, 1, 1).unwrap() + duration,
+    ///     NaiveDate::from_ymd_opt(2023, 1, 1).unwrap()
     /// );
     /// ```
     pub fn from_duration_between(start: NaiveDate, end: NaiveDate) -> RelativeDuration {
@@ -325,47 +325,47 @@ mod tests {
     #[test]
     fn test_from_duration_transits_year() {
         let duration = RelativeDuration::from_duration_between(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveDate::from_ymd(2023, 1, 1),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
         );
 
         assert_eq!(
-            NaiveDate::from_ymd(2022, 1, 1) + duration,
-            NaiveDate::from_ymd(2023, 1, 1)
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap() + duration,
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap()
         );
     }
 
     #[test]
     fn test_from_duration_transits_month() {
         let duration = RelativeDuration::from_duration_between(
-            NaiveDate::from_ymd(2023, 3, 1),
-            NaiveDate::from_ymd(2023, 3, 31),
+            NaiveDate::from_ymd_opt(2023, 3, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2023, 3, 31).unwrap(),
         );
 
         assert_eq!(
-            NaiveDate::from_ymd(2023, 3, 1) + duration,
-            NaiveDate::from_ymd(2023, 3, 31)
+            NaiveDate::from_ymd_opt(2023, 3, 1).unwrap() + duration,
+            NaiveDate::from_ymd_opt(2023, 3, 31).unwrap()
         );
     }
 
     #[test]
     fn test_from_duration_transits_months_and_days() {
         let duration = RelativeDuration::from_duration_between(
-            NaiveDate::from_ymd(2023, 3, 1),
-            NaiveDate::from_ymd(2023, 4, 20),
+            NaiveDate::from_ymd_opt(2023, 3, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2023, 4, 20).unwrap(),
         );
 
         assert_eq!(
-            NaiveDate::from_ymd(2023, 3, 1) + duration,
-            NaiveDate::from_ymd(2023, 4, 20)
+            NaiveDate::from_ymd_opt(2023, 3, 1).unwrap() + duration,
+            NaiveDate::from_ymd_opt(2023, 4, 20).unwrap()
         );
     }
 
     #[test]
     fn test_from_duration_between_year() {
         let duration = RelativeDuration::from_duration_between(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveDate::from_ymd(2023, 1, 1),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
         );
 
         assert_eq!(duration.num_months(), 12);
@@ -376,8 +376,8 @@ mod tests {
     #[test]
     fn test_from_duration_between_month() {
         let duration = RelativeDuration::from_duration_between(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveDate::from_ymd(2022, 2, 1),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2022, 2, 1).unwrap(),
         );
 
         assert_eq!(duration.num_months(), 1);
@@ -487,7 +487,7 @@ mod tests {
     #[test]
     fn test_add_year() {
         let rd = RelativeDuration::months(12);
-        let next = NaiveDate::from_ymd(2022, 1, 1) + rd;
-        assert_eq!(next, NaiveDate::from_ymd(2023, 1, 1));
+        let next = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap() + rd;
+        assert_eq!(next, NaiveDate::from_ymd_opt(2023, 1, 1).unwrap());
     }
 }

--- a/src/interval/base.rs
+++ b/src/interval/base.rs
@@ -67,13 +67,13 @@ impl Interval {
     /// use calends::{Interval, IntervalLike, RelativeDuration};
     /// use calends::interval::marker::{End, Start};
     ///
-    /// let start = NaiveDate::from_ymd(2022, 1, 1);
+    /// let start = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
     /// let duration = RelativeDuration::months(1).with_days(-1);
     ///
     /// let mut interval = Interval::closed_from_start(start, duration);
     ///
     /// assert_eq!(interval.start_opt().unwrap(), start);
-    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd(2022, 1, 31));
+    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd_opt(2022, 1, 31).unwrap());
     /// ```
     pub fn closed_from_start(date: NaiveDate, duration: RelativeDuration) -> Self {
         Interval::Closed(ClosedInterval::from_start(date, duration))
@@ -89,12 +89,12 @@ impl Interval {
     /// use calends::interval::marker::{End, Start};
     ///
     /// let interval = Interval::closed_from_end(
-    ///     NaiveDate::from_ymd(2022, 1, 1),
+    ///     NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
     ///     RelativeDuration::months(1).with_weeks(-2).with_days(2),
     /// );
     ///
-    /// assert_eq!(interval.start_opt().unwrap(), NaiveDate::from_ymd(2021, 12, 13));
-    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd(2022, 1, 1));
+    /// assert_eq!(interval.start_opt().unwrap(), NaiveDate::from_ymd_opt(2021, 12, 13).unwrap());
+    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd_opt(2022, 1, 1).unwrap());
     /// ```
     pub fn closed_from_end(end: NaiveDate, duration: RelativeDuration) -> Self {
         Interval::Closed(ClosedInterval::from_end(end, duration))
@@ -110,12 +110,12 @@ impl Interval {
     /// use calends::interval::marker::{End, Start};
     ///
     /// let interval = Interval::closed_with_dates(
-    ///     NaiveDate::from_ymd(2022, 1, 1),
-    ///     NaiveDate::from_ymd(2023, 1, 1),
+    ///     NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
     /// );
     ///
-    /// assert_eq!(interval.start_opt().unwrap(), NaiveDate::from_ymd(2022, 1, 1));
-    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd(2023, 1, 1));
+    /// assert_eq!(interval.start_opt().unwrap(), NaiveDate::from_ymd_opt(2022, 1, 1).unwrap());
+    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd_opt(2023, 1, 1).unwrap());
     /// ```
     pub fn closed_with_dates(start: NaiveDate, end: NaiveDate) -> Self {
         Interval::Closed(ClosedInterval::with_dates(start, end))
@@ -204,12 +204,12 @@ impl IntervalWithStart {
     /// use calends::interval::marker::{End, Start};
     ///
     /// let interval = IntervalWithStart::closed_with_dates(
-    ///     NaiveDate::from_ymd(2022, 1, 1),
-    ///     NaiveDate::from_ymd(2023, 1, 1),
+    ///     NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
     /// );
     ///
-    /// assert_eq!(interval.start_opt().unwrap(), NaiveDate::from_ymd(2022, 1, 1));
-    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd(2023, 1, 1));
+    /// assert_eq!(interval.start_opt().unwrap(), NaiveDate::from_ymd_opt(2022, 1, 1).unwrap());
+    /// assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd_opt(2023, 1, 1).unwrap());
     /// ```
     pub fn closed_with_dates(start: NaiveDate, end: NaiveDate) -> Self {
         IntervalWithStart::Closed(ClosedInterval::with_dates(start, end))
@@ -313,16 +313,17 @@ mod tests {
 
     #[test]
     fn test_reciprocity() {
-        let start = NaiveDate::from_ymd(2022, 1, 1);
-        let interval = Interval::closed_with_dates(start, NaiveDate::from_ymd(2022, 12, 31));
+        let start = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+        let interval =
+            Interval::closed_with_dates(start, NaiveDate::from_ymd_opt(2022, 12, 31).unwrap());
 
         assert_eq!(
             interval.start_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 1, 1)
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()
         );
         assert_eq!(
             interval.end_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 12, 31)
+            NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()
         );
 
         let duration = interval.duration().unwrap();
@@ -335,54 +336,72 @@ mod tests {
     #[test]
     fn test_interval_closed_from_start() {
         let mut iter = Interval::closed_from_start(
-            NaiveDate::from_ymd(2022, 1, 1),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
             RelativeDuration::months(1),
         )
-        .until_after(NaiveDate::from_ymd(2023, 1, 1))
+        .until_after(NaiveDate::from_ymd_opt(2023, 1, 1).unwrap())
         .unwrap();
 
         let next = iter.next().unwrap();
-        assert_eq!(next.start_opt().unwrap(), NaiveDate::from_ymd(2022, 1, 1));
-        assert_eq!(next.end_opt().unwrap(), NaiveDate::from_ymd(2022, 2, 1));
+        assert_eq!(
+            next.start_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()
+        );
+        assert_eq!(
+            next.end_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2022, 2, 1).unwrap()
+        );
 
         let next = iter.next().unwrap();
-        assert_eq!(next.start_opt().unwrap(), NaiveDate::from_ymd(2022, 2, 1));
-        assert_eq!(next.end_opt().unwrap(), NaiveDate::from_ymd(2022, 3, 1));
+        assert_eq!(
+            next.start_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2022, 2, 1).unwrap()
+        );
+        assert_eq!(
+            next.end_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2022, 3, 1).unwrap()
+        );
 
         let next = iter.next().unwrap();
-        assert_eq!(next.start_opt().unwrap(), NaiveDate::from_ymd(2022, 3, 1));
+        assert_eq!(
+            next.start_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2022, 3, 1).unwrap()
+        );
     }
 
     #[test]
     fn test_interval_closed_from_end() {
         let interval = Interval::closed_from_end(
-            NaiveDate::from_ymd(2022, 1, 1),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
             RelativeDuration::months(1).with_weeks(-2).with_days(2),
         );
 
         assert_eq!(
             interval.start_opt().unwrap(),
-            NaiveDate::from_ymd(2021, 12, 13)
+            NaiveDate::from_ymd_opt(2021, 12, 13).unwrap()
         );
-        assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd(2022, 1, 1));
+        assert_eq!(
+            interval.end_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()
+        );
     }
 
     #[test]
     fn test_interval_closed_with_dates() {
         let mut iter = Interval::closed_with_dates(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveDate::from_ymd(2023, 1, 1),
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
         )
-        .until_after(NaiveDate::from_ymd(2025, 1, 1))
+        .until_after(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap())
         .unwrap();
 
         assert_eq!(
             iter.next().unwrap().start_opt(),
-            Some(NaiveDate::from_ymd(2022, 1, 1))
+            Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap())
         );
         assert_eq!(
             iter.next().unwrap().start_opt(),
-            Some(NaiveDate::from_ymd(2023, 1, 1))
+            Some(NaiveDate::from_ymd_opt(2023, 1, 1).unwrap())
         );
     }
 }

--- a/src/interval/bound.rs
+++ b/src/interval/bound.rs
@@ -23,7 +23,7 @@ where
         (None, None) => Ordering::Equal,
         (None, Some(_)) => Ordering::Greater,
         (Some(_), None) => Ordering::Less,
-        (Some(r1), Some(ref r2)) => r1.cmp(r2),
+        (Some(r1), Some(r2)) => r1.cmp(r2),
     }
 }
 

--- a/src/interval/like.rs
+++ b/src/interval/like.rs
@@ -97,19 +97,19 @@ mod tests {
     #[test]
     fn test_within() {
         let i1 = Int {
-            start: NaiveDate::from_ymd(2022, 1, 1),
-            end: NaiveDate::from_ymd(2022, 12, 31),
+            start: NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            end: NaiveDate::from_ymd_opt(2022, 12, 31).unwrap(),
         };
 
-        assert!(i1.within(NaiveDate::from_ymd(2022, 5, 18)));
-        assert!(!i1.within(NaiveDate::from_ymd(2023, 5, 18)));
+        assert!(i1.within(NaiveDate::from_ymd_opt(2022, 5, 18).unwrap()));
+        assert!(!i1.within(NaiveDate::from_ymd_opt(2023, 5, 18).unwrap()));
     }
 
     #[test]
     fn test_start_date() {
         let i1 = Int {
-            start: NaiveDate::from_ymd(2022, 1, 1),
-            end: NaiveDate::from_ymd(2022, 12, 31),
+            start: NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            end: NaiveDate::from_ymd_opt(2022, 12, 31).unwrap(),
         };
 
         assert_eq!(i1.start_opt(), NaiveDate::from_ymd_opt(2022, 1, 1));
@@ -118,8 +118,8 @@ mod tests {
     #[test]
     fn test_end_date() {
         let i1 = Int {
-            start: NaiveDate::from_ymd(2022, 1, 1),
-            end: NaiveDate::from_ymd(2022, 12, 31),
+            start: NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            end: NaiveDate::from_ymd_opt(2022, 12, 31).unwrap(),
         };
 
         assert_eq!(i1.end_opt(), NaiveDate::from_ymd_opt(2022, 12, 31));
@@ -128,8 +128,8 @@ mod tests {
     #[test]
     fn test_iso8601() {
         let i = Int {
-            start: NaiveDate::from_ymd(2022, 1, 1),
-            end: NaiveDate::from_ymd(2022, 12, 31),
+            start: NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            end: NaiveDate::from_ymd_opt(2022, 12, 31).unwrap(),
         };
 
         assert_eq!(i.iso8601(), "2022-01-01/2022-12-31")

--- a/src/interval/marker.rs
+++ b/src/interval/marker.rs
@@ -25,9 +25,11 @@ mod tests {
 
     #[test]
     fn test_all_intervals() {
-        let i1 = OpenStartInterval::new(NaiveDate::from_ymd(2022, 1, 1));
-        let i2 =
-            ClosedInterval::from_start(NaiveDate::from_ymd(2022, 1, 1), RelativeDuration::days(2));
+        let i1 = OpenStartInterval::new(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap());
+        let i2 = ClosedInterval::from_start(
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+            RelativeDuration::days(2),
+        );
 
         fn interval<I: IntervalLike + marker::End>(interval: I) -> (Option<NaiveDate>, NaiveDate) {
             (interval.start_opt(), interval.end())
@@ -35,10 +37,10 @@ mod tests {
 
         let i1 = interval(i1);
         assert_eq!(i1.0, None);
-        assert_eq!(i1.1, NaiveDate::from_ymd(2022, 1, 1));
+        assert_eq!(i1.1, NaiveDate::from_ymd_opt(2022, 1, 1).unwrap());
 
         let i2 = interval(i2);
-        assert_eq!(i2.0, Some(NaiveDate::from_ymd(2022, 1, 1)));
-        assert_eq!(i2.1, NaiveDate::from_ymd(2022, 1, 3));
+        assert_eq!(i2.0, Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()));
+        assert_eq!(i2.1, NaiveDate::from_ymd_opt(2022, 1, 3).unwrap());
     }
 }

--- a/src/interval/parse.rs
+++ b/src/interval/parse.rs
@@ -17,7 +17,10 @@ pub fn parse_date(i: &[u8]) -> IResult<&[u8], NaiveDate> {
     let (i, _) = tag(b"-")(i)?;
     let (i, day) = take_n_digits(i, 2)?;
 
-    Ok((i, NaiveDate::from_ymd(year.try_into().unwrap(), month, day)))
+    Ok((
+        i,
+        NaiveDate::from_ymd_opt(year.try_into().unwrap(), month, day).unwrap(),
+    ))
 }
 
 fn parse_start_and_duration(i: &[u8]) -> IResult<&[u8], ClosedInterval> {
@@ -59,6 +62,9 @@ mod tests {
     #[test]
     fn test_parse_interval() {
         let (_i, interval) = parse_interval("2022-01-01/2023-01-01".as_bytes()).unwrap();
-        assert_eq!(interval.end_opt().unwrap(), NaiveDate::from_ymd(2023, 1, 1))
+        assert_eq!(
+            interval.end_opt().unwrap(),
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap()
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@
 //!
 //! // It also compatible with NaiveDate
 //! assert_eq!(
-//!     NaiveDate::from_ymd(2022, 1, 1) + rd,
-//!     NaiveDate::from_ymd(2022, 1, 30)
+//!     NaiveDate::from_ymd_opt(2022, 1, 1).unwrap() + rd,
+//!     NaiveDate::from_ymd_opt(2022, 1, 30).unwrap()
 //! );
 //! ```
 //!
@@ -77,12 +77,12 @@
 //! use calends::{Recurrence, Rule};
 //! use chrono::NaiveDate;
 //!
-//! let date = NaiveDate::from_ymd(2022, 1, 1);
-//! let end = NaiveDate::from_ymd(2022, 3, 1);
+//! let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+//! let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
 //!
 //! let mut recur = Recurrence::with_start(Rule::monthly(), date).until(end);
-//! assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-//! assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+//! assert_eq!(recur.next(), NaiveDate::from_ymd_opt(2022, 1, 1));
+//! assert_eq!(recur.next(), NaiveDate::from_ymd_opt(2022, 2, 1));
 //! assert_eq!(recur.next(), None);
 //! ```
 //!
@@ -105,7 +105,7 @@
 //! use chrono::NaiveDate;
 //!
 //! let duration = RelativeDuration::months(1).with_days(-2);
-//! let start = NaiveDate::from_ymd(2022, 1, 1);
+//! let start = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
 //!
 //! let mut interval = Interval::closed_from_start(start, duration);
 //! ```
@@ -128,7 +128,7 @@
 //! }
 //!
 //! let rd = RelativeDuration::default().with_days(1).with_months(23).with_weeks(-1);
-//! let int = Interval::closed_from_start(NaiveDate::from_ymd(2022, 1, 1), rd);
+//! let int = Interval::closed_from_start(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), rd);
 //! let s = S { i: int.clone() };
 //!
 //! let int_string = serde_json::to_string(&s).unwrap();

--- a/src/recurrence/recur.rs
+++ b/src/recurrence/recur.rs
@@ -94,12 +94,12 @@ impl Recurrence {
     /// use calends::{Recurrence, Rule};
     /// use chrono::NaiveDate;
     ///
-    /// let date = NaiveDate::from_ymd(2022, 1, 1);
-    /// let end = NaiveDate::from_ymd(2022, 3, 1);
+    /// let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+    /// let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
     ///
     /// let mut recur = Recurrence::with_start(Rule::monthly(), date);
-    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()));
+    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 2, 1).unwrap()));
     /// ```
     pub fn with_start(rule: Rule, date: NaiveDate) -> Self {
         Self {
@@ -115,12 +115,12 @@ impl Recurrence {
     /// use calends::{Recurrence, Rule};
     /// use chrono::NaiveDate;
     ///
-    /// let date = NaiveDate::from_ymd(2022, 1, 1);
-    /// let end = NaiveDate::from_ymd(2022, 3, 1);
+    /// let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+    /// let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
     ///
     /// let mut recur = Recurrence::with_start(Rule::monthly(), date).until(end);
-    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()));
+    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 2, 1).unwrap()));
     /// assert_eq!(recur.next(), None);
     /// ```
     pub fn until(&self, date: NaiveDate) -> Until<Recurrence> {
@@ -133,12 +133,12 @@ impl Recurrence {
     /// use calends::{Recurrence, Rule};
     /// use chrono::NaiveDate;
     ///
-    /// let date = NaiveDate::from_ymd(2022, 1, 1);
-    /// let end = NaiveDate::from_ymd(2022, 3, 1);
+    /// let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+    /// let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
     ///
     /// let mut recur = Recurrence::with_start(Rule::monthly(), date).until(end);
-    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()));
+    /// assert_eq!(recur.next(), Some(NaiveDate::from_ymd_opt(2022, 2, 1).unwrap()));
     /// assert_eq!(recur.next(), None);
     /// ```
     pub fn until_and_including(&self, date: NaiveDate) -> Until<Recurrence> {
@@ -175,42 +175,69 @@ mod tests {
 
     #[test]
     fn test_recur_monthly_until_inclusive() {
-        let date = NaiveDate::from_ymd(2022, 1, 1);
-        let end = NaiveDate::from_ymd(2022, 3, 1);
+        let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
 
         let mut recur = Recurrence::with_start(Rule::monthly(), date).until_and_including(end);
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 3, 1)));
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap())
+        );
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 2, 1).unwrap())
+        );
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 3, 1).unwrap())
+        );
         assert_eq!(recur.next(), None);
     }
 
     #[test]
     fn test_recur_monthly_until_exclusive() {
-        let date = NaiveDate::from_ymd(2022, 1, 1);
-        let end = NaiveDate::from_ymd(2022, 3, 1);
+        let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2022, 3, 1).unwrap();
 
         let mut recur = Recurrence::with_start(Rule::monthly(), date).until(end);
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap())
+        );
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 2, 1).unwrap())
+        );
         assert_eq!(recur.next(), None);
     }
 
     #[test]
     fn test_recur_monthly() {
-        let date = NaiveDate::from_ymd(2022, 1, 1);
+        let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
 
         let mut recur = Recurrence::with_start(Rule::monthly(), date);
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 2, 1)));
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap())
+        );
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 2, 1).unwrap())
+        );
     }
 
     #[test]
     fn test_recur_quarterly() {
-        let date = NaiveDate::from_ymd(2022, 1, 1);
+        let date = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap();
 
         let mut recur = Recurrence::with_start(Rule::quarterly(), date);
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 1, 1)));
-        assert_eq!(recur.next(), Some(NaiveDate::from_ymd(2022, 4, 1)));
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap())
+        );
+        assert_eq!(
+            recur.next(),
+            Some(NaiveDate::from_ymd_opt(2022, 4, 1).unwrap())
+        );
     }
 }

--- a/src/unit/convert.rs
+++ b/src/unit/convert.rs
@@ -40,12 +40,12 @@ mod tests {
     #[test]
     fn test_convert_week() {
         assert_eq!(
-            convert_to_iso_week(NaiveDate::from_ymd(2020, 2, 29)),
+            convert_to_iso_week(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()),
             CalendarUnit::Week(2020, 9)
         );
 
         assert_eq!(
-            convert_to_iso_week(NaiveDate::from_ymd(2022, 12, 31)),
+            convert_to_iso_week(NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()),
             CalendarUnit::Week(2022, 52)
         )
     }
@@ -53,12 +53,12 @@ mod tests {
     #[test]
     fn test_convert_month() {
         assert_eq!(
-            convert_to_month(NaiveDate::from_ymd(2020, 2, 29)),
+            convert_to_month(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()),
             CalendarUnit::Month(2020, 2)
         );
 
         assert_eq!(
-            convert_to_month(NaiveDate::from_ymd(2022, 12, 31)),
+            convert_to_month(NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()),
             CalendarUnit::Month(2022, 12)
         )
     }
@@ -66,12 +66,12 @@ mod tests {
     #[test]
     fn test_convert_quarter() {
         assert_eq!(
-            convert_to_quarter(NaiveDate::from_ymd(2020, 2, 29)),
+            convert_to_quarter(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()),
             CalendarUnit::Quarter(2020, 1)
         );
 
         assert_eq!(
-            convert_to_quarter(NaiveDate::from_ymd(2022, 12, 31)),
+            convert_to_quarter(NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()),
             CalendarUnit::Quarter(2022, 4)
         )
     }
@@ -79,12 +79,12 @@ mod tests {
     #[test]
     fn test_convert_half() {
         assert_eq!(
-            convert_to_half(NaiveDate::from_ymd(2020, 2, 29)),
+            convert_to_half(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()),
             CalendarUnit::Half(2020, 1)
         );
 
         assert_eq!(
-            convert_to_half(NaiveDate::from_ymd(2022, 12, 31)),
+            convert_to_half(NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()),
             CalendarUnit::Half(2022, 2)
         )
     }
@@ -92,12 +92,12 @@ mod tests {
     #[test]
     fn test_convert_year() {
         assert_eq!(
-            convert_to_year(NaiveDate::from_ymd(2020, 2, 29)),
+            convert_to_year(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap()),
             CalendarUnit::Year(2020)
         );
 
         assert_eq!(
-            convert_to_year(NaiveDate::from_ymd(2022, 12, 31)),
+            convert_to_year(NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()),
             CalendarUnit::Year(2022)
         )
     }

--- a/src/unit/domain.rs
+++ b/src/unit/domain.rs
@@ -32,26 +32,26 @@ impl CalendarUnit {
     pub fn into_interval(&self) -> Interval {
         let res = match self {
             CalendarUnit::Year(year) => ClosedInterval::from_start(
-                NaiveDate::from_yo(*year, 1),
+                NaiveDate::from_yo_opt(*year, 1).unwrap(),
                 RelativeDuration::months(12).with_days(-1),
             ),
             CalendarUnit::Quarter(year, quarter) => ClosedInterval::from_start(
-                NaiveDate::from_ymd(*year, (*quarter * 3 - 2).try_into().unwrap(), 1),
+                NaiveDate::from_ymd_opt(*year, (*quarter * 3 - 2).try_into().unwrap(), 1).unwrap(),
                 RelativeDuration::months(3).with_days(-1),
             ),
 
             CalendarUnit::Half(year, half) => ClosedInterval::from_start(
-                NaiveDate::from_ymd(*year, (*half * 6 - 5).try_into().unwrap(), 1),
+                NaiveDate::from_ymd_opt(*year, (*half * 6 - 5).try_into().unwrap(), 1).unwrap(),
                 RelativeDuration::months(6).with_days(-1),
             ),
 
             CalendarUnit::Month(year, month) => ClosedInterval::from_start(
-                NaiveDate::from_ymd(*year, (*month).try_into().unwrap(), 1),
+                NaiveDate::from_ymd_opt(*year, (*month).try_into().unwrap(), 1).unwrap(),
                 RelativeDuration::months(1).with_days(-1),
             ),
 
             CalendarUnit::Week(year, week) => ClosedInterval::from_start(
-                NaiveDate::from_isoywd(*year, (*week).into(), chrono::Weekday::Mon),
+                NaiveDate::from_isoywd_opt(*year, (*week).into(), chrono::Weekday::Mon).unwrap(),
                 RelativeDuration::days(7),
             ),
         };
@@ -161,21 +161,21 @@ mod tests {
         let interval = CalendarUnit::Quarter(2022, 1).into_interval();
         assert_eq!(
             interval.start_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 1, 1)
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()
         );
         assert_eq!(
             interval.end_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 3, 31)
+            NaiveDate::from_ymd_opt(2022, 3, 31).unwrap()
         );
 
         let interval = CalendarUnit::Quarter(2022, 2).into_interval();
         assert_eq!(
             interval.start_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 4, 1)
+            NaiveDate::from_ymd_opt(2022, 4, 1).unwrap()
         );
         assert_eq!(
             interval.end_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 6, 30)
+            NaiveDate::from_ymd_opt(2022, 6, 30).unwrap()
         );
     }
 
@@ -184,11 +184,11 @@ mod tests {
         let interval = CalendarUnit::Half(2022, 2).into_interval();
         assert_eq!(
             interval.start_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 7, 1)
+            NaiveDate::from_ymd_opt(2022, 7, 1).unwrap()
         );
         assert_eq!(
             interval.end_opt().unwrap(),
-            NaiveDate::from_ymd(2022, 12, 31)
+            NaiveDate::from_ymd_opt(2022, 12, 31).unwrap()
         );
     }
 }

--- a/src/util/search.rs
+++ b/src/util/search.rs
@@ -4,7 +4,7 @@ use crate::shift;
 
 // Borrowed from bdays
 pub fn days_in_month(year: i32, month: u32) -> u32 {
-    NaiveDate::from_ymd(
+    NaiveDate::from_ymd_opt(
         match month {
             12 => year + 1,
             _ => year,
@@ -15,12 +15,13 @@ pub fn days_in_month(year: i32, month: u32) -> u32 {
         },
         1,
     )
-    .signed_duration_since(NaiveDate::from_ymd(year, month, 1))
+    .unwrap()
+    .signed_duration_since(NaiveDate::from_ymd_opt(year, month, 1).unwrap())
     .num_days() as u32
 }
 
 pub fn find_weekday_ascending(weekday: Weekday, yy: i32, mm: u32, occurrence: u32) -> NaiveDate {
-    let anchor = NaiveDate::from_ymd(yy, mm, 1);
+    let anchor = NaiveDate::from_ymd_opt(yy, mm, 1).unwrap();
     let mut offset = (weekday.number_from_monday() + 7 - anchor.weekday().number_from_monday()) % 7;
 
     if occurrence > 1 {
@@ -44,7 +45,10 @@ pub fn find_weekday_descending(weekday: Weekday, yy: i32, mm: u32, occurrence: u
 
 /// Weeks in year
 pub fn weeks_in_year(date: &NaiveDate) -> u32 {
-    NaiveDate::from_ymd(date.year(), 12, 31).iso_week().week()
+    NaiveDate::from_ymd_opt(date.year(), 12, 31)
+        .unwrap()
+        .iso_week()
+        .week()
 }
 
 /// Returns the quarter start month
@@ -62,22 +66,25 @@ pub fn month_end(mut yy: i32, mut mm: u32) -> NaiveDate {
         mm += 1;
     }
 
-    NaiveDate::from_ymd(yy, mm, 1).pred()
+    NaiveDate::from_ymd_opt(yy, mm, 1)
+        .unwrap()
+        .pred_opt()
+        .unwrap()
 }
 
 #[inline]
 pub fn beginning_of_quarter(d: &NaiveDate) -> NaiveDate {
-    NaiveDate::from_ymd(d.year(), quarter_month(d), 1)
+    NaiveDate::from_ymd_opt(d.year(), quarter_month(d), 1).unwrap()
 }
 
 #[inline]
 pub fn beginning_of_year(d: &NaiveDate) -> NaiveDate {
-    NaiveDate::from_ymd(d.year(), 1, 1)
+    NaiveDate::from_ymd_opt(d.year(), 1, 1).unwrap()
 }
 
 #[inline]
 pub fn beginning_of_month(d: &NaiveDate) -> NaiveDate {
-    NaiveDate::from_ymd(d.year(), d.month(), 1)
+    NaiveDate::from_ymd_opt(d.year(), d.month(), 1).unwrap()
 }
 
 /// Beginning of a biweek
@@ -90,10 +97,10 @@ pub fn beginning_of_month(d: &NaiveDate) -> NaiveDate {
 #[inline]
 pub fn beginning_of_biweek(d: &NaiveDate) -> NaiveDate {
     let beginning = if d.iso_week().week() % 2 == 0 {
-        NaiveDate::from_isoywd(d.iso_week().year(), d.iso_week().week(), Weekday::Mon)
+        NaiveDate::from_isoywd_opt(d.iso_week().year(), d.iso_week().week(), Weekday::Mon).unwrap()
             - Duration::weeks(1)
     } else {
-        NaiveDate::from_isoywd(d.iso_week().year(), d.iso_week().week(), Weekday::Mon)
+        NaiveDate::from_isoywd_opt(d.iso_week().year(), d.iso_week().week(), Weekday::Mon).unwrap()
     };
 
     debug_assert!(
@@ -112,17 +119,17 @@ pub fn beginning_of_biweek(d: &NaiveDate) -> NaiveDate {
 ///
 #[inline]
 pub fn beginning_of_week(d: &NaiveDate) -> NaiveDate {
-    NaiveDate::from_isoywd(d.iso_week().year(), d.iso_week().week(), Weekday::Mon)
+    NaiveDate::from_isoywd_opt(d.iso_week().year(), d.iso_week().week(), Weekday::Mon).unwrap()
 }
 
 #[inline]
 pub fn end_of_year(d: &NaiveDate) -> NaiveDate {
-    NaiveDate::from_ymd(d.year(), 12, 31)
+    NaiveDate::from_ymd_opt(d.year(), 12, 31).unwrap()
 }
 
 #[inline]
 pub fn end_of_quarter(d: &NaiveDate) -> NaiveDate {
-    shift::shift_quarters(*d, 1).pred()
+    shift::shift_quarters(*d, 1).pred_opt().unwrap()
 }
 
 #[inline]
@@ -131,17 +138,19 @@ pub fn end_of_month(d: &NaiveDate) -> NaiveDate {
     let year = d.year();
     let days_in_month = days_in_month(year, month);
 
-    NaiveDate::from_ymd(year, month, days_in_month)
+    NaiveDate::from_ymd_opt(year, month, days_in_month).unwrap()
 }
 
 #[inline]
 pub fn end_of_biweek(d: &NaiveDate) -> NaiveDate {
-    shift::shift_weeks(beginning_of_biweek(d), 2).pred()
+    shift::shift_weeks(beginning_of_biweek(d), 2)
+        .pred_opt()
+        .unwrap()
 }
 
 #[inline]
 pub fn end_of_week(d: &NaiveDate) -> NaiveDate {
-    NaiveDate::from_isoywd(d.iso_week().year(), d.iso_week().week(), Weekday::Sun)
+    NaiveDate::from_isoywd_opt(d.iso_week().year(), d.iso_week().week(), Weekday::Sun).unwrap()
 }
 
 #[cfg(test)]
@@ -156,8 +165,8 @@ mod tests {
     #[test]
     fn test_beginning_of_biweek() {
         assert_eq!(
-            beginning_of_biweek(&NaiveDate::from_ymd(2022, 1, 1)),
-            NaiveDate::from_ymd(2021, 12, 20)
+            beginning_of_biweek(&NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()),
+            NaiveDate::from_ymd_opt(2021, 12, 20).unwrap()
         )
     }
 

--- a/src/util/shift.rs
+++ b/src/util/shift.rs
@@ -12,14 +12,14 @@ use crate::util;
 /// # use chrono::NaiveDate;
 /// # use calends::util::shift_months;
 ///
-/// let n1 = shift_months(NaiveDate::from_ymd(2022, 1, 1), 1);
-/// assert_eq!(n1, NaiveDate::from_ymd(2022, 2, 1));
+/// let n1 = shift_months(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), 1);
+/// assert_eq!(n1, NaiveDate::from_ymd_opt(2022, 2, 1).unwrap());
 ///
-/// let n2 = shift_months(NaiveDate::from_ymd(2022, 2, 3), 2);
-/// assert_eq!(n2, NaiveDate::from_ymd(2022, 4, 3));
+/// let n2 = shift_months(NaiveDate::from_ymd_opt(2022, 2, 3).unwrap(), 2);
+/// assert_eq!(n2, NaiveDate::from_ymd_opt(2022, 4, 3).unwrap());
 ///
-/// let n3 = shift_months(NaiveDate::from_ymd(2022, 2, 3), -1);
-/// assert_eq!(n3, NaiveDate::from_ymd(2022, 1, 3));
+/// let n3 = shift_months(NaiveDate::from_ymd_opt(2022, 2, 3).unwrap(), -1);
+/// assert_eq!(n3, NaiveDate::from_ymd_opt(2022, 1, 3).unwrap());
 /// ```
 ///
 /// The behavior for end of month works as follows:
@@ -29,12 +29,12 @@ use crate::util;
 /// # use calends::util::shift_months;
 ///
 /// assert_eq!(
-///   shift_months(NaiveDate::from_ymd(2022, 2, 28), 1),
-///   NaiveDate::from_ymd(2022, 3, 31)
+///   shift_months(NaiveDate::from_ymd_opt(2022, 2, 28).unwrap(), 1),
+///   NaiveDate::from_ymd_opt(2022, 3, 31).unwrap()
 /// );
 /// assert_eq!(
-///   shift_months(NaiveDate::from_ymd(2022, 3, 31), 1),
-///   NaiveDate::from_ymd(2022, 4, 30)
+///   shift_months(NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(), 1),
+///   NaiveDate::from_ymd_opt(2022, 4, 30).unwrap()
 /// );
 /// ```
 ///
@@ -44,8 +44,8 @@ use crate::util;
 /// # use chrono::NaiveDate;
 /// # use calends::util::shift_months;
 ///
-/// let n4 = shift_months(NaiveDate::from_ymd(2022, 2, 28), 11);
-/// assert_eq!(n4, NaiveDate::from_ymd(2023, 1, 31));
+/// let n4 = shift_months(NaiveDate::from_ymd_opt(2022, 2, 28).unwrap(), 11);
+/// assert_eq!(n4, NaiveDate::from_ymd_opt(2023, 1, 31).unwrap());
 /// ```
 ///
 ///
@@ -69,7 +69,7 @@ pub fn shift_months(date: NaiveDate, months: i32) -> NaiveDate {
         // month
         std::cmp::min(date.day(), util::month_end(year, month as u32).day())
     };
-    NaiveDate::from_ymd(year, month as u32, day)
+    NaiveDate::from_ymd_opt(year, month as u32, day).unwrap()
 }
 
 /// Add a quarter to the date supplied
@@ -86,8 +86,8 @@ pub fn shift_months(date: NaiveDate, months: i32) -> NaiveDate {
 /// # use chrono::NaiveDate;
 /// # use dateutil::addition;
 ///
-/// assert_eq!(addition::add_quarter_duration(NaiveDate::from_ymd(2022, 1, 1)), NaiveDate::from_ymd(2022, 4, 1));
-/// assert_eq!(addition::add_quarter_duration(NaiveDate::from_ymd(2022, 11, 3)), NaiveDate::from_ymd(2023, 2, 3));
+/// assert_eq!(addition::add_quarter_duration(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap()), NaiveDate::from_ymd_opt(2022, 4, 1).unwrap());
+/// assert_eq!(addition::add_quarter_duration(NaiveDate::from_ymd_opt(2022, 11, 3).unwrap()), NaiveDate::from_ymd_opt(2023, 2, 3).unwrap());
 ///
 /// ```
 #[inline]
@@ -103,11 +103,11 @@ pub fn shift_quarters(date: NaiveDate, quarters: i32) -> NaiveDate {
 /// # use chrono::NaiveDate;
 /// # use calends::shift_years;
 ///
-/// let n1 = shift_years(NaiveDate::from_ymd(2022, 1, 1), 1);
-/// let n2 = shift_years(NaiveDate::from_ymd(1584, 2, 3), -1);
+/// let n1 = shift_years(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), 1);
+/// let n2 = shift_years(NaiveDate::from_ymd_opt(1584, 2, 3).unwrap(), -1);
 ///
-/// assert_eq!(n1, NaiveDate::from_ymd(2023, 1, 1));
-/// assert_eq!(n2, NaiveDate::from_ymd(1583, 2, 3));
+/// assert_eq!(n1, NaiveDate::from_ymd_opt(2023, 1, 1).unwrap());
+/// assert_eq!(n2, NaiveDate::from_ymd_opt(1583, 2, 3).unwrap());
 ///
 /// ```
 #[inline]
@@ -136,34 +136,34 @@ mod tests {
     #[test]
     fn test_shift_months() {
         assert_eq!(
-            shift_months(NaiveDate::from_ymd(2022, 1, 1), 1),
-            NaiveDate::from_ymd(2022, 2, 1)
+            shift_months(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), 1),
+            NaiveDate::from_ymd_opt(2022, 2, 1).unwrap()
         );
 
         assert_eq!(
-            shift_months(NaiveDate::from_ymd(2022, 1, 1), -1),
-            NaiveDate::from_ymd(2021, 12, 1)
+            shift_months(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), -1),
+            NaiveDate::from_ymd_opt(2021, 12, 1).unwrap()
         )
     }
 
     #[test]
     fn test_shift_quarters() {
         assert_eq!(
-            shift_quarters(NaiveDate::from_ymd(2022, 1, 1), 1),
-            NaiveDate::from_ymd(2022, 4, 1)
+            shift_quarters(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), 1),
+            NaiveDate::from_ymd_opt(2022, 4, 1).unwrap()
         );
     }
 
     #[test]
     fn test_shift_years() {
         assert_eq!(
-            shift_years(NaiveDate::from_ymd(2022, 1, 1), 1),
-            NaiveDate::from_ymd(2023, 1, 1)
+            shift_years(NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(), 1),
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap()
         );
 
         assert_eq!(
-            shift_years(NaiveDate::from_ymd(2024, 2, 29), 1),
-            NaiveDate::from_ymd(2025, 2, 28)
+            shift_years(NaiveDate::from_ymd_opt(2024, 2, 29).unwrap(), 1),
+            NaiveDate::from_ymd_opt(2025, 2, 28).unwrap()
         );
     }
 }


### PR DESCRIPTION
Sorry for the unsolicited PR, but the deprecation warnings were bugging me...
Updated all flagged chrono builders with their `_opt...unwrap()` equivalents.  chrono API is a bit tedious.
Also changed one ref-to-a-ref nag in `bound.rs`.

Bonus, all tests still pass!